### PR TITLE
Display test result in user friendly format;

### DIFF
--- a/app/src/main/java/dgca/wallet/app/android/certificate/claim/TestViewHolder.kt
+++ b/app/src/main/java/dgca/wallet/app/android/certificate/claim/TestViewHolder.kt
@@ -34,7 +34,7 @@ import dgca.wallet.app.android.parseFromTo
 class TestViewHolder(private val binding: ItemTestBinding) : RecyclerView.ViewHolder(binding.root) {
 
     fun bind(data: TestModel) {
-        binding.testResultValue.text = data.testResult
+        binding.testResultValue.text = data.resultType.value
         binding.dateOfCollectionValue.text = data.dateTimeOfCollection.parseFromTo(DATE_TIME, FORMATTED_DATE_TIME)
         binding.dateOfTestResultValue.text = data.dateTimeOfTestResult?.parseFromTo(DATE_TIME, FORMATTED_DATE_TIME)
         binding.diseaseValue.text = data.disease

--- a/app/src/main/java/dgca/wallet/app/android/data/CertificateModel.kt
+++ b/app/src/main/java/dgca/wallet/app/android/data/CertificateModel.kt
@@ -61,8 +61,14 @@ data class TestModel(
     val testingCentre: String,
     val countryOfVaccination: String,
     val certificateIssuer: String,
-    val certificateIdentifier: String
+    val certificateIdentifier: String,
+    val resultType: TestResult
 ) : CertificateData
+
+enum class TestResult(val value: String) {
+    DETECTED("DETECTED"),
+    NOT_DETECTED("NOT DETECTED")
+}
 
 data class RecoveryModel(
     override val disease: String,

--- a/app/src/main/java/dgca/wallet/app/android/data/local/Mapper.kt
+++ b/app/src/main/java/dgca/wallet/app/android/data/local/Mapper.kt
@@ -59,8 +59,16 @@ fun Test.toTestModel(): TestModel {
         testingCentre,
         countryOfVaccination,
         certificateIssuer,
-        certificateIdentifier
+        certificateIdentifier,
+        getTestResultType().toTestResult()
     )
+}
+
+fun Test.TestResult.toTestResult(): TestResult {
+    return when (this) {
+        Test.TestResult.DETECTED -> TestResult.DETECTED
+        Test.TestResult.NOT_DETECTED -> TestResult.NOT_DETECTED
+    }
 }
 
 fun Vaccination.toVaccinationModel(): VaccinationModel {


### PR DESCRIPTION
closes #28 