### PR TITLE
- skip certificate validation if base45 not decoded;

### DIFF
--- a/app/src/main/java/dgca/wallet/app/android/certificate/DefaultGreenCertificateFetcher.kt
+++ b/app/src/main/java/dgca/wallet/app/android/certificate/DefaultGreenCertificateFetcher.kt
@@ -45,6 +45,11 @@ class DefaultGreenCertificateFetcher(
         val verificationResult = VerificationResult()
         val plainInput = prefixValidationService.decode(qrString, verificationResult)
         val compressedCose = base45Service.decode(plainInput, verificationResult)
+        if (verificationResult.base45Decoded.not()) {
+            Timber.d("Verification failed: base45 not decoded")
+            return Pair(null, null)
+        }
+
         val coseResult: ByteArray? = compressorService.decode(compressedCose, verificationResult)
 
         if (coseResult == null) {

--- a/app/src/main/java/dgca/wallet/app/android/certificate/claim/ClaimCertificateFragment.kt
+++ b/app/src/main/java/dgca/wallet/app/android/certificate/claim/ClaimCertificateFragment.kt
@@ -80,6 +80,8 @@ class ClaimCertificateFragment : BindingFragment<FragmentCertificateClaimBinding
             if (certificate != null) {
                 showUserData(certificate)
                 adapter.update(certificate.getCertificateListData())
+            } else {
+                findNavController().popBackStack()
             }
         })
         viewModel.init(args.qrCodeText)


### PR DESCRIPTION
- fix navigation when decoding failed;