### PR TITLE
Fixed device credential log in dialog text

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     testImplementation Deps.test_junit
     testImplementation Deps.mockito_core
     testImplementation Deps.mockito_kotlin
+    testImplementation Deps.mockito_inline
     testImplementation Deps.appache_commons
 
     androidTestImplementation Deps.test_ext

--- a/app/src/main/java/dgca/wallet/app/android/ui/AuthFragment.kt
+++ b/app/src/main/java/dgca/wallet/app/android/ui/AuthFragment.kt
@@ -142,7 +142,7 @@ class AuthFragment : BindingFragment<FragmentAuthBinding>() {
 
     private fun showDeviceCredentialPrompt() {
         generateSecretKey(generateKeyGenParameterSpec())
-        promptInfo = getPrompInfo()
+        promptInfo = getPrompInfo(false)
         biometricPrompt.authenticate(promptInfo)
     }
 
@@ -175,19 +175,21 @@ class AuthFragment : BindingFragment<FragmentAuthBinding>() {
         return spec.build()
     }
 
-    private fun getPrompInfo(withBiometric: Boolean = false): BiometricPrompt.PromptInfo {
-        val prompt = BiometricPrompt.PromptInfo.Builder()
-            .setTitle(getString(R.string.biometric_dialog_title))
-            .setSubtitle(getString(R.string.biometric_dialog_subtitle))
-
-        if (withBiometric) {
-            prompt.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
-            prompt.setNegativeButtonText(getString(R.string.biometric_dialog_cancel))
-        } else {
-            prompt.setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK or BiometricManager.Authenticators.DEVICE_CREDENTIAL)
-        }
-
-        return prompt.build()
+    private fun getPrompInfo(withBiometric: Boolean): BiometricPrompt.PromptInfo {
+        return BiometricPrompt.PromptInfo.Builder()
+            .apply {
+                if (withBiometric) {
+                    setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG)
+                    setNegativeButtonText(getString(R.string.biometric_dialog_cancel))
+                    setTitle(getString(R.string.biometric_dialog_title))
+                    setSubtitle(getString(R.string.biometric_dialog_subtitle))
+                } else {
+                    setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_WEAK or BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+                    setTitle(getString(R.string.device_credential_dialog_title))
+                    setSubtitle(getString(R.string.device_credential_dialog_subtitle))
+                }
+            }
+            .build()
     }
 
     private fun encryptSecretInformation(cryptoObject: BiometricPrompt.CryptoObject?) {

--- a/branches/dcc/src/main/res/values/strings.xml
+++ b/branches/dcc/src/main/res/values/strings.xml
@@ -31,9 +31,9 @@
     <string name="done">Done</string>
     <string name="retry">Retry</string>
     <string name="biometric_dialog_title">Biometric login</string>
-    <string name="biometric_dialog_subtitle">Log in using your biometric credential</string>
+    <string name="biometric_dialog_subtitle">Log in using your biometric credential.</string>
     <string name="device_credential_dialog_title">Login</string>
-    <string name="device_credential_dialog_subtitle">Log in with your device credentials</string>
+    <string name="device_credential_dialog_subtitle">Log in with your device credentials.</string>
     <string name="biometric_dialog_cancel">Cancel</string>
     <string name="date_of_vaccination_title">Date of Vaccination</string>
     <string name="issuer_country">Issuer Country</string>

--- a/branches/dcc/src/main/res/values/strings.xml
+++ b/branches/dcc/src/main/res/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="retry">Retry</string>
     <string name="biometric_dialog_title">Biometric login</string>
     <string name="biometric_dialog_subtitle">Log in using your biometric credential</string>
+    <string name="device_credential_dialog_title">Device credential login</string>
+    <string name="device_credential_dialog_subtitle">Log in using your device credential</string>
     <string name="biometric_dialog_cancel">Cancel</string>
     <string name="date_of_vaccination_title">Date of Vaccination</string>
     <string name="issuer_country">Issuer Country</string>

--- a/branches/dcc/src/main/res/values/strings.xml
+++ b/branches/dcc/src/main/res/values/strings.xml
@@ -32,8 +32,8 @@
     <string name="retry">Retry</string>
     <string name="biometric_dialog_title">Biometric login</string>
     <string name="biometric_dialog_subtitle">Log in using your biometric credential</string>
-    <string name="device_credential_dialog_title">Device credential login</string>
-    <string name="device_credential_dialog_subtitle">Log in using your device credential</string>
+    <string name="device_credential_dialog_title">Login</string>
+    <string name="device_credential_dialog_subtitle">Log in with your device credentials</string>
     <string name="biometric_dialog_cancel">Cancel</string>
     <string name="date_of_vaccination_title">Date of Vaccination</string>
     <string name="issuer_country">Issuer Country</string>

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -28,7 +28,7 @@ object Config {
     const val targetSdk = 29
     val javaVersion = JavaVersion.VERSION_1_8
 
-    const val versionCode = 55
+    const val versionCode = 56
     const val versionName = "1.3.2"
 
     const val androidTestInstrumentation = "androidx.test.runner.AndroidJUnitRunner"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -86,6 +86,7 @@ object Deps {
     const val test_runner = "androidx.test:runner:${Versions.test_rules}}"
     const val mockito_core = "org.mockito:mockito-core:${Versions.mockito_core_version}"
     const val mockito_kotlin = "org.mockito.kotlin:mockito-kotlin:${Versions.mockito_kotlin_version}"
+    const val mockito_inline = "org.mockito:mockito-inline:${Versions.mockito_kotlin_version}"
 
     const val test_ext = "androidx.test.ext:junit:${Versions.test_ext}"
     const val test_rules = "androidx.test:rules:${Versions.test_rules}"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -85,5 +85,4 @@ object Versions {
     const val test_rules = "1.3.0"
     const val mockito_core_version = "3.9.0"
     const val mockito_kotlin_version = "3.2.0"
-    const val mockito_inline_version = "2.7.21"
 }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -85,4 +85,5 @@ object Versions {
     const val test_rules = "1.3.0"
     const val mockito_core_version = "3.9.0"
     const val mockito_kotlin_version = "3.2.0"
+    const val mockito_inline_version = "2.7.21"
 }


### PR DESCRIPTION
Tickets:
https://github.com/eu-digital-green-certificates/dgca-wallet-app-android/issues/196
https://trello.com/c/FVzQyipw/44-ros-finding-63-wallet-app-login-dialog-wrongly-claim-to-biometric-even-when-it-is-not

![device-credential-log-in](https://user-images.githubusercontent.com/82441124/169687680-4adb12d4-238f-4973-8460-de20b40f469a.png)
![biometric-credential-log-in](https://user-images.githubusercontent.com/82441124/169687682-4dd84799-95fa-41e5-a6e1-86d5b83be8eb.png)
